### PR TITLE
Fix "event is not defined" error in formlogic.js

### DIFF
--- a/practice-time-labs/reminder-service-step-functions-api-gateway/site/formlogic.js
+++ b/practice-time-labs/reminder-service-step-functions-api-gateway/site/formlogic.js
@@ -23,21 +23,21 @@ function clearNotifications() {
 }
 
 // Add listeners for each button that make the API request
-document.getElementById('bothButton').addEventListener('click', function() {
-    sendData('both');
+document.getElementById('bothButton').addEventListener('click', function(e) {
+    sendData(e, 'both');
 });
 
-document.getElementById('emailButton').addEventListener('click', function() {
-    sendData('email');
+document.getElementById('emailButton').addEventListener('click', function(e) {
+    sendData(e, 'email');
 });
 
-document.getElementById('smsButton').addEventListener('click', function() {
-    sendData('sms');
+document.getElementById('smsButton').addEventListener('click', function(e) {
+    sendData(e, 'sms');
 });
 
-function sendData (pref) {
+function sendData (e, pref) {
     // Prevent the page reloading and clear exisiting notifications
-    event.preventDefault()
+    e.preventDefault()
     clearNotifications()
     // Prepare the appropriate HTTP request to the API with fetch
     // create uses the root /prometheon endpoint and requires a JSON payload


### PR DESCRIPTION
While doing the "Creating Your Own Serverless Reminder Service on AWS with Step Functions, API Gateway, Lambda and S3" activity, I found that the buttons in the static site don't work in Firefox. Opening the console shows the following error:
> ReferenceError: event is not defined                    formlogic.js:40:5 

This is happening because the "event" variable isn't being passed to the "sendData" function. The reason it works in Chrome is because Chrome defines a global variable for "event", which is a non-standard kludge for IE compatibility. See [Why is 'event' variable available even when not passed as a parameter?](https://stackoverflow.com/questions/33167092/why-is-event-variable-available-even-when-not-passed-as-a-parameter)

Also, I renamed `event` to `e` to avoid variable shadowing.

P.S. Great job on the course! It's really well done.